### PR TITLE
feat: auto-deploy to Cloudflare Pages on main push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build site
+        run: pnpm exec astro build
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_ACCOUNT_ID: b339105698961d09ea892bf3cafe5678
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          pnpm dlx wrangler pages deploy dist \
+            --project-name takashiaihara-site \
+            --branch main \
+            --commit-dirty=true

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,13 +1,16 @@
 import image from "@astrojs/image";
 import mdx from "@astrojs/mdx";
 import partytown from "@astrojs/partytown";
-import sitemap from "@astrojs/sitemap";
 import { defineConfig } from "astro/config";
+
+// sitemap integration is temporarily disabled because @astrojs/sitemap@2.0.2
+// passes an absolute destinationDir to sitemap@7.1.3 which rejects it.
+// Re-enable after the Astro upgrade in #13.
 
 // https://astro.build/config
 export default defineConfig({
   site: "https://takashiaihara.site",
-  integrations: [mdx(), sitemap(),
+  integrations: [mdx(),
     image({
       serviceEntryPoint: '@astrojs/image/sharp',
     }),

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "type": "module",
   "version": "0.0.1",
   "private": true,
+  "packageManager": "pnpm@11.0.9",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "deploy:prod": "vercel --prod",
-    "deploy:dev": "vercel",
+    "deploy": "pnpm dlx wrangler pages deploy dist --project-name takashiaihara-site --branch main --commit-dirty=true",
     "astro": "astro"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Closes #18

main への push を契機に Cloudflare Pages へ自動 deploy する GitHub Actions workflow を整備。同時に main を壊さないように、build を fail させていた `@astrojs/sitemap` を一時無効化。

## Changes

- `.github/workflows/deploy.yml` (new)
  - trigger: push to main, workflow_dispatch
  - pnpm/action-setup@v4 + setup-node@v4 (Node 22, pnpm cache)
  - `pnpm install --frozen-lockfile` → `pnpm exec astro build` → `pnpm dlx wrangler pages deploy dist`
  - `CLOUDFLARE_ACCOUNT_ID` は直書き (機密性なし)、`CLOUDFLARE_API_TOKEN` は repo secret
  - concurrency: deploy-\${{ github.ref }} (cancel-in-progress: false)
  - permissions: contents: read
  - timeout: 10min
- `astro.config.mjs`
  - sitemap integration を削除 (Astro 2.10 と sitemap@7 の互換性問題で build が fail する。復活は #13 の Astro 5 上げで対応)
- `package.json`
  - `packageManager: pnpm@11.0.9` 追加 (CI と local 揃え)
  - `deploy:prod` / `deploy:dev` (vercel) を `deploy` (wrangler pages deploy) に置換

## マージ前にやってもらうこと

- [ ] repo secret `CLOUDFLARE_API_TOKEN` を登録 (`gh secret set CLOUDFLARE_API_TOKEN -R TakashiAihara/takashi-aihara.info`、stdin で貼り付け)

## マージ後

- Actions の "Deploy to Cloudflare Pages" run が green になることを確認
- Cloudflare Pages dashboard で新しい deployment が見えることを確認
- `curl -I https://takashiaihara.site/` が引き続き 200

## 関連

- #12 (closed) 初回 manual deploy
- #19 token rotate (Actions secret に新 token を入れた後に旧 token を delete)
- #13 Astro 5 上げ (sitemap 復活)