### PR TITLE
feat: move site to profile.takashiaihara.site and parameterize via GH variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,14 +32,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build site
+        env:
+          SITE_DOMAIN: ${{ vars.SITE_DOMAIN }}
         run: pnpm exec astro build
 
       - name: Deploy to Cloudflare Pages
         env:
           CLOUDFLARE_ACCOUNT_ID: b339105698961d09ea892bf3cafe5678
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: |
-          pnpm dlx wrangler pages deploy dist \
-            --project-name takashiaihara-site \
-            --branch main \
-            --commit-dirty=true
+        run: pnpm dlx wrangler pages deploy --branch main --commit-dirty=true

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,8 +8,10 @@ import { defineConfig } from "astro/config";
 // Re-enable after the Astro upgrade in #13.
 
 // https://astro.build/config
+const siteDomain = process.env.SITE_DOMAIN || "profile.takashiaihara.site";
+
 export default defineConfig({
-  site: "https://takashiaihara.site",
+  site: `https://${siteDomain}`,
   integrations: [mdx(),
     image({
       serviceEntryPoint: '@astrojs/image/sharp',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "deploy": "pnpm dlx wrangler pages deploy dist --project-name takashiaihara-site --branch main --commit-dirty=true",
+    "deploy": "pnpm dlx wrangler pages deploy",
     "astro": "astro"
   },
   "dependencies": {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,2 @@
+name = "takashiaihara-site"
+pages_build_output_dir = "dist"


### PR DESCRIPTION
## Summary

Part of #22 (PR 1/2)

apex `takashiaihara.site` から subdomain `profile.takashiaihara.site` に移行。同時に `SITE_DOMAIN` を GH Variable 化、Pages project 名は `wrangler.toml` に集約。apex は Cloudflare Single Redirect で 301 → profile に向ける。

## Changes

- `wrangler.toml` (new): `name = "takashiaihara-site"`, `pages_build_output_dir = "dist"`
  - これにより `wrangler pages deploy` だけで OK (環境変数経由は wrangler 未サポートのため config file 経由が正解)
- `astro.config.mjs`: `site` を `process.env.SITE_DOMAIN || "profile.takashiaihara.site"` 参照
  - 空文字列も fallback 対象にしたいので `||` (`??` だと invalid url になる)
- `.github/workflows/deploy.yml`:
  - Build step に `SITE_DOMAIN: ${{ vars.SITE_DOMAIN }}` を追加
  - Deploy step から `--project-name` を撤去 (wrangler.toml 経由)
- `package.json`: `deploy` script を `pnpm dlx wrangler pages deploy` まで短縮

## GH Configuration

| 種類 | キー | 値 | 説明 |
| --- | --- | --- | --- |
| Variable | `SITE_DOMAIN` | `profile.takashiaihara.site` | 別 subdomain repo でも同名で使い回す |
| Secret | `CLOUDFLARE_API_TOKEN` | (rotated) | 既存、変更なし |

## Cloudflare Configuration

このセッション内で API 設定済み:

- Pages custom domain `profile.takashiaihara.site` を `takashiaihara-site` project に attach (status: initializing → active 待ち)
- DNS `CNAME profile → takashiaihara-site.pages.dev` (proxied=true)
- Single Redirect rule (apex → profile, 301) は dashboard で手動設定済み (Rulesets API は token 権限不足)

apex `takashiaihara.site` 自体は Pages の custom domain として残置 (= edge で hit して redirect rule 実行)。

## 動作確認 TODO

- [ ] Actions run が green
- [ ] https://profile.takashiaihara.site/ で 200 (全 5 ページ)
- [ ] https://takashiaihara.site/ が 301 → profile に redirect
- [ ] https://takashiaihara.site/bio が 301 → https://profile.takashiaihara.site/bio (path 保持)
- [ ] curl で `Location:` header 検証

## 続き

- PR2: repo rename + `SITE_REPOSITORY_URL` / README の追従