### PR TITLE
chore: update internal references to new repo and subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # TakashiAihara's About Page Source
 
-Published in [This URL](https://takashiaihara.site)
+Published in [This URL](https://profile.takashiaihara.site)

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -5,7 +5,7 @@
 export const SITE_TITLE = "About TakashiAihara";
 export const SITE_DESCRIPTION = "About TakashiAihara";
 export const SITE_REPOSITORY_URL =
-  "https://github.com/TakashiAihara/takashi-aihara.info";
+  "https://github.com/TakashiAihara/profile.takashiaihara.site";
 export const ASTRO_REPOSITORY_URL = "https://github.com/withastro/astro";
 
 // SEO


### PR DESCRIPTION
## Summary

Part of #22 (PR 2/2)

`gh repo rename` で `takashi-aihara.info` → `profile.takashiaihara.site` を実施 (旧 URL は GitHub 側で redirect されるので即時破壊なし)。本 PR は内部参照を新名に追従。

## Changes

- `src/consts.ts`: `SITE_REPOSITORY_URL` → `https://github.com/TakashiAihara/profile.takashiaihara.site`
- `README.md`: link → `https://profile.takashiaihara.site`

## やったこと (Out of diff)

- `gh repo rename`: GitHub 側で repo 名変更
- `git remote set-url`: ローカル remote pointer 更新
- ghq dir 物理 rename はやらない (Claude session の cwd 死活問題回避)

## 動作確認 TODO

- [ ] Actions が新 repo URL で問題なく動作 (Actions の secret/variable は repo 名に紐づかないので継続)
- [ ] Footer 等の SITE_REPOSITORY_URL リンクが新 URL に
- [ ] 古い URL (`takashi-aihara.info`) へのアクセスも GitHub の redirect で生きる

## 後始末 (ユーザー手元での作業候補)

- ghq dir rename or 新 clone (任意):
  ```bash
  # 旧 dir はそのまま、新 path に clone (cwd を変えない場合)
  ghq get TakashiAihara/profile.takashiaihara.site
  # ※ 旧 dir は今のセッションのため残置、別 session で `ghq rm TakashiAihara/takashi-aihara.info` 可
  ```
- 他マシンの clone も同様に追従 (`git remote set-url`)

## 完了後

- #22 close