### PR TITLE
chore: refresh profile content (SITE meta + BIO + CARRIER years)

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,8 +2,9 @@
 // You can import this data from anywhere in your site by using the `import` keyword.
 
 // Site Core Information
-export const SITE_TITLE = "About TakashiAihara";
-export const SITE_DESCRIPTION = "About TakashiAihara";
+export const SITE_TITLE = "Takashi Aihara - Profile";
+export const SITE_DESCRIPTION =
+  "Full-stack engineer crossing infrastructure, backend, and frontend. AI-first development, IaC, and 60+ niche tech posts on Zenn.";
 export const SITE_REPOSITORY_URL =
   "https://github.com/TakashiAihara/profile.takashiaihara.site";
 export const ASTRO_REPOSITORY_URL = "https://github.com/withastro/astro";
@@ -77,11 +78,11 @@ export const HEADER_CONTENT_SETTINGS = [
 export const IT_CARRIER_SUMMARY_SETTINGS = [
   {
     summary: "Lead Web Developer (Tech Lead)",
-    year: 2,
+    year: 4,
   },
   {
     summary: "Backend Engineer",
-    year: 2,
+    year: 6,
   },
   {
     summary: "Frontend Engineer",
@@ -97,7 +98,7 @@ export const IT_CARRIER_SUMMARY_SETTINGS = [
   },
   {
     summary: "On-premises Infrastructure Engineer",
-    year: 2,
+    year: 4,
   },
 ];
 
@@ -114,19 +115,19 @@ export const DANCER_CARRIER_SUMMARY_SETTINGS = [
 
 export const BIO_SUMMARY_SETTINGS = [
   {
-    content: "I am working as a freelance IT engineer",
+    content: "Full-stack engineer crossing infra, backend, and frontend",
     emoji: "🧑‍💻",
   },
   {
-    content: "I also want to develop games",
-    emoji: "🎮",
+    content: "I lead delivery platform design & AI tooling at work",
+    emoji: "⚙️",
   },
   {
-    content: "I also worked as an amateur dancer",
-    emoji: "🕺",
+    content: "I share niche tech notes on Zenn (60+ posts)",
+    emoji: "📝",
   },
   {
-    content: "I want to create fun things!",
+    content: "I want to keep shipping fun things!",
     emoji: "✨",
   },
 ];


### PR DESCRIPTION
## Summary

Closes #14

`src/consts.ts` のプロフィール文言を 2026-06 時点の現状に合わせて更新。`findy/resume.md` (転職用 resume) と Zenn / Qiita / GitHub 各アカウントの公開情報を抽象化した内容に差し替えた。会社名は出さず、職務上の役割と発信活動を中心に構成。

## Changes (single file, 12 insertions / 11 deletions)

### SITE meta
- `SITE_TITLE`: `About TakashiAihara` → `Takashi Aihara - Profile`
- `SITE_DESCRIPTION`: 空っぽ的内容 → 1 行の self-pitch (full-stack / AI-first / IaC / Zenn 60+)

### BIO_SUMMARY_SETTINGS (4 件、構造維持)
| before | after |
| --- | --- |
| `I am working as a freelance IT engineer` 🧑‍💻 | `Full-stack engineer crossing infra, backend, and frontend` 🧑‍💻 |
| `I also want to develop games` 🎮 | `I lead delivery platform design & AI tooling at work` ⚙️ |
| `I also worked as an amateur dancer` 🕺 | `I share niche tech notes on Zenn (60+ posts)` 📝 |
| `I want to create fun things!` ✨ | `I want to keep shipping fun things!` ✨ |

`amateur dancer` 言及は `/bio` ページの `DANCER_CARRIER_SUMMARY_SETTINGS` (Hiphop 5 / B-boying 4) で残しているため、bio ページ自体には dance section が引き続き表示される。

### IT_CARRIER_SUMMARY_SETTINGS (6 件、年数のみ更新)
| 項目 | before | after |
| --- | --- | --- |
| Lead Web Developer (Tech Lead) | 2 | 4 |
| Backend Engineer | 2 | 6 |
| Frontend Engineer | 1 | 1 (維持) |
| IT Research Analyst | 1 | 1 (維持) |
| On-site Help Desk | 2 | 2 (維持) |
| On-premises Infrastructure Engineer | 2 | 4 |

年数の根拠: `findy/resume.md` の各 project 期間を集計 (モノクレア Lead + Mico RCS/SMS Lead で Tech Lead 約 4 年、Mico + EV + モノクレア + コミクリ で Backend 約 6 年、アイ・ユー・ケイ + ジェイテック で On-premises Infra 約 4 年)。

## Out of scope (別 Issue 化候補)

- Twitter (X) handle `takashi__aihara` の生死確認 (X.com は 402 で取れず未確認)
- public/anime_face.png 等の画像差し替え (#14 任意項目)

## 動作確認

- `pnpm exec astro build` exit=0
- `dist/index.html` の `<title>`、description meta、BIO 文言 4 件、CARRIER 役割名 すべて新値で反映確認

## Sources (BIO 抽象化のソース)

- https://zenn.dev/takashiaihara (59 posts、自己紹介: "インフラとかバックエンドとかフロントエンドとか")
- https://qiita.com/TakashiAihara (2 posts、Kubernetes / RaspberryPi 中心)
- https://github.com/TakashiAihara (Bio: フロント/バック/オンプレ/ヘルプデスク/Tech Lead、Next.js + tRPC + Prisma 関心)